### PR TITLE
Edited printable area

### DIFF
--- a/instructions/Maskless_Design_Rules_Tolerances_v1.mdown
+++ b/instructions/Maskless_Design_Rules_Tolerances_v1.mdown
@@ -3,7 +3,7 @@ Design Rules
 - Channel size >/= 100 um in width in increments of 50 um
 - Channel sizes >/= 50 um in height in increments of 25 um (to be improved to 10 um)
 - Spacing between channels >/= 0.5 mm
-- Overall printable are within 30 mm x 50 mm
+- Overall printable area within 8.5 mm x 24 mm
 
 Tolerances
 


### PR DESCRIPTION
Fixed typo on "area".
Changed printable area to that of small mold, taking into account area that will actually print accurately.